### PR TITLE
feat(core): skeleton janus.sh with main menu (#3)

### DIFF
--- a/scripts/auth.sh
+++ b/scripts/auth.sh
@@ -50,10 +50,10 @@ else
   trap 'rm -f "${tmpfile}"' EXIT
 
   dialog --backtitle "${DIALOG_BACKTITLE}" \
-         --title 'Login required' \
-         --form 'Please enter your Janus credentials:' 10 50 0 \
-         'Username:'  1 1 '' 1 15 30 0 \
-         'Password:'  2 1 '' 2 15 30 0 2> "${tmpfile}"
+       --title 'Login required' \
+       --mixedform 'Please enter your Janus credentials:' 12 50 0 \
+       'Username:'  1 1 '' 1 15 30 0 0 \
+       'Password:'  2 1 '' 2 15 30 0 1 2> "${tmpfile}"
 
   USER_LOGIN=$(sed -n 1p "${tmpfile}")
   USER_PWD=$(sed -n 2p "${tmpfile}")

--- a/scripts/janus.sh
+++ b/scripts/janus.sh
@@ -1,6 +1,49 @@
 #!/usr/bin/env bash
 
-SESSION_TOKEN=$(auth.sh) || { echo "Authentication failed"; exit 1; }
+: '
+janus.sh - main script
 
-export JANUS_SESSION="$SESSION_TOKEN"
-echo "Session token: $JANUS_SESSION"
+- handles authentication using auth.sh
+- displays a TUI to connect to machines or view logs
+'
+
+set -euo pipefail
+
+echo -e "       █████   █████████   ██████   █████ █████  █████  █████████ \n      ░░███   ███░░░░░███ ░░██████ ░░███ ░░███  ░░███  ███░░░░░███\n       ░███  ░███    ░███  ░███░███ ░███  ░███   ░███ ░███    ░░░ \n       ░███  ░███████████  ░███░░███░███  ░███   ░███ ░░█████████ \n       ░███  ░███░░░░░███  ░███ ░░██████  ░███   ░███  ░░░░░░░░███\n ███   ░███  ░███    ░███  ░███  ░░█████  ░███   ░███  ███    ░███\n░░████████   █████   █████ █████  ░░█████ ░░████████  ░░█████████ \n ░░░░░░░░   ░░░░░   ░░░░░ ░░░░░    ░░░░░   ░░░░░░░░    ░░░░░░░░
+"
+./scripts/auth.sh
+if [ $? -ne 0 ]; then
+  echo "Authentication failed or cancelled. Exiting."
+  exit 1
+fi
+
+while true; do
+  CHOICE=$(dialog --backtitle "Janus Bastion" --title "Main Menu" \
+    --menu "Select an action:" 15 50 5 \
+    "1" "Connect to a machine" \
+    "2" "Settings" \
+    "3" "Quit" \
+    3>&1 1>&2 2>&3)
+
+  EXIT_STATUS=$?
+  if [ $EXIT_STATUS -ne 0 ]; then
+    # Non-zero exit code => user pressed ESC or Cancel
+    break
+  fi
+
+  # 3. Handle the user's choice (placeholders for now)
+  case "$CHOICE" in
+    "1")
+      dialog --msgbox "Connect to a machine - not implemented yet." 6 50
+      ;;
+    "2")
+      dialog --msgbox "Settings - not implemented yet." 6 50
+      ;;
+    "3")
+      break
+      ;;
+  esac
+done
+
+clear
+echo "Goodbye!"


### PR DESCRIPTION
introduces the main orchestrator script `janus.sh`. After successful authentication via `auth.sh`,

- Implements: #3
- Based on: `feat/02-dialog-login-ui`

✅ Authentication must succeed to proceed
✅ Menu includes placeholder options:
  - Connect to a machine (no)
  - View logs (no)
  - Quit (no)

Next steps:
- Implement SSH/RDP connection logic
- Display user-accessible machines from DB
